### PR TITLE
falling chests are now barrels with chicken parachutes. Also adds dro…

### DIFF
--- a/src/me/lukemccon/airdrop/Airdrop.java
+++ b/src/me/lukemccon/airdrop/Airdrop.java
@@ -10,11 +10,16 @@ import me.lukemccon.airdrop.packages.PackageManager;
 
 public class Airdrop extends JavaPlugin {
 	
+	public static Airdrop PLUGIN_INSTANCE;
+	
 	@Override
 	public void onEnable() {
 		
+		PLUGIN_INSTANCE = this;
+		
 		// Register Commands
 		this.getCommand("airdrop").setExecutor(new CmdAirdrop());
+		this.getCommand("dropzone").setExecutor(new CmdDropzone());
 		
 		// Register Listeners
 		Bukkit.getPluginManager().registerEvents(new FallingBlockListener(), this);

--- a/src/me/lukemccon/airdrop/Crate.java
+++ b/src/me/lukemccon/airdrop/Crate.java
@@ -2,13 +2,19 @@ package me.lukemccon.airdrop;
 
 import java.util.ArrayList;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Barrel;
 import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
+import org.bukkit.entity.Chicken;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Slime;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 import me.lukemccon.airdrop.helpers.CrateList;
 
@@ -44,7 +50,63 @@ public class Crate {
 	@SuppressWarnings("deprecation")
 	public void dropCrate() {
 
-		fallingCrate = world.spawnFallingBlock(location, Material.OAK_PLANKS, (byte) 0);
+		// Create a tiny invisible slime to hold leashes for the crate
+		Slime parachuteLeash = (Slime) world.spawnEntity(location.add(new Vector(0, 1, 0)), EntityType.SLIME);
+		parachuteLeash.setAI(false);
+		parachuteLeash.setSize(1);
+		parachuteLeash.setInvisible(true);
+		parachuteLeash.setInvulnerable(true);
+
+		fallingCrate = world.spawnFallingBlock(location, Material.BARREL, (byte) 0);
+		
+		// Create a bunch of chicken parachuters and attach them to the slime
+		ArrayList<Chicken> chickenParachutes = new ArrayList<Chicken>();
+		for(int i = 0; i < 5; i++) {
+			Chicken chicken = (Chicken) world.spawnEntity(location.add(new Vector(Math.random()*0.25, 1, Math.random()*0.25)), EntityType.CHICKEN);
+			chicken.setInvulnerable(true);
+			chicken.setLeashHolder(parachuteLeash);
+			chickenParachutes.add(chicken);
+		}
+					
+		// Add the tiny slime as a passenger on the fallingCrate, this will make it looks like the crate is holding the chicken leashes
+		fallingCrate.addPassenger(parachuteLeash);
+		
+		fallingCrate.setGravity(false);
+		
+		Bukkit.getServer().getScheduler().runTaskTimer(Airdrop.PLUGIN_INSTANCE, new Runnable() {
+			
+			@Override
+			public void run() {
+				// When the fallingCrate dies, have the chickens fly away for 3 seconds then despawn
+				if(fallingCrate.isDead()) {
+					for(Chicken c : chickenParachutes) {
+						c.setLeashHolder(null);
+						double xVel = Math.random() < 0.5 ? Math.random()*0.5*-1 : Math.random()*0.5;
+						double zVel = Math.random() < 0.5 ? Math.random()*0.5*-1 : Math.random()*0.5;
+						c.setVelocity(new Vector(xVel, 0.5, zVel));
+						Bukkit.getServer().getScheduler().runTaskLater(Airdrop.PLUGIN_INSTANCE, new Runnable() {
+							@Override
+							public void run() {
+								c.remove();
+								return;
+							}
+						}, 60);
+					}
+					parachuteLeash.remove();
+					return;
+				}
+				
+				// Play some smoke effects
+				fallingCrate.getWorld().playEffect(fallingCrate.getLocation().add(new Vector(0, 1, 0)), Effect.SMOKE, 0);
+				fallingCrate.getWorld().playEffect(fallingCrate.getLocation().add(new Vector(0, 1, 0)), Effect.SMOKE, 0);
+				fallingCrate.getWorld().playEffect(fallingCrate.getLocation().add(new Vector(0, 1, 0)), Effect.SMOKE, 0);
+				
+				// Set the falling vector repeatedly to ensure the crate doesn't slow down due to no gravity
+				fallingCrate.setVelocity(new Vector(0, -0.3, 0));
+
+			}
+			
+		}, 0, 2);
 		
 		CrateList.crateMap.put(fallingCrate, this);
 
@@ -55,13 +117,15 @@ public class Crate {
 	 */
 	public void spawnChest() {
 
-		blockChest.setType(Material.CHEST);
-
-		Chest chest = (Chest) blockChest.getState();
+		blockChest.setType(Material.BARREL);
+		
+		Barrel barrel = (Barrel) blockChest.getState();
 
 		for (ItemStack is : contents) {
-			chest.getBlockInventory().addItem(is);
+			barrel.getInventory().addItem(is);
 		}
+		
+		CrateList.barrelList.add(barrel.getLocation());
 
 	}
 	

--- a/src/me/lukemccon/airdrop/commands/CmdDropzone.java
+++ b/src/me/lukemccon/airdrop/commands/CmdDropzone.java
@@ -1,0 +1,99 @@
+package me.lukemccon.airdrop.commands;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+import me.lukemccon.airdrop.Airdrop;
+import me.lukemccon.airdrop.Crate;
+import me.lukemccon.airdrop.exceptions.PackageNotFoundException;
+import me.lukemccon.airdrop.helpers.DropHelper;
+
+public class CmdDropzone implements CommandExecutor {
+	
+	private Location corner1;
+	private Location corner2;
+	private World world;
+	private int frequencyInSeconds = 10;
+	private BukkitTask dropzoneRunnerId;
+	
+	private Random r = new Random();
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		
+		if(sender instanceof Player) {
+			Player player = (Player) sender;
+			
+			switch(args[0]) {
+			case "setWorld":
+				this.world = player.getWorld();
+			case "setCorner1":
+				this.corner1 = player.getLocation();
+				return true;
+			case "setCorner2":
+				this.corner2 = player.getLocation();
+				return true;
+			case "setFrequency":
+				try {
+					this.frequencyInSeconds = Integer.parseInt(args[1]);
+				} catch (NumberFormatException e) {
+					player.sendMessage("Not a number");
+					return false;
+				}
+			case "enable":
+				if(corner1 == null || corner2 == null) {
+					player.sendMessage("One of the corners isn't set");
+					return false;
+				}
+				dropzoneRunnerId = Bukkit.getServer().getScheduler().runTaskTimer(Airdrop.PLUGIN_INSTANCE, new Runnable() {
+					@Override
+					public void run() {
+						int xMax = Math.max(corner1.getBlockX(), corner2.getBlockX());
+						int xMin = Math.min(corner1.getBlockX(), corner2.getBlockX());
+						int zMax = Math.max(corner1.getBlockZ(), corner2.getBlockZ());
+						int zMin = Math.min(corner1.getBlockZ(), corner2.getBlockZ());
+
+						int xLoc = r.nextInt(xMax - xMin) + xMin;
+						int zLoc = r.nextInt(zMax - zMin) + zMin;
+						Location dropLocation = world.getHighestBlockAt(xLoc, zLoc).getLocation().add(new Vector(0.5, 50, 0.5));
+						ArrayList<ItemStack> items;
+						try {
+							items = DropHelper.getItemsInPackage("starter", null);
+						} catch (PackageNotFoundException e) {
+							items = new ArrayList<ItemStack>();
+						}
+						
+						Bukkit.getServer().broadcastMessage("Dropping an airdrop at X: " + xLoc + ", Z: " + zLoc);
+						
+						Crate crate = new Crate(dropLocation, world, items);	
+						crate.dropCrate();
+					}
+				}, frequencyInSeconds * 20, frequencyInSeconds*20);
+				return true;
+			case "disable":
+				if (dropzoneRunnerId != null) {
+					dropzoneRunnerId.cancel();
+					return true;
+				}
+				return false;
+			default:
+				player.sendMessage("Invalid, use setCorner1, setCorner2, enable, or disable.");
+			}
+			
+		}
+		
+		return false;
+	}
+
+}

--- a/src/me/lukemccon/airdrop/helpers/CrateList.java
+++ b/src/me/lukemccon/airdrop/helpers/CrateList.java
@@ -1,8 +1,10 @@
 package me.lukemccon.airdrop.helpers;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Location;
 import org.bukkit.entity.FallingBlock;
 
 import me.lukemccon.airdrop.Crate;
@@ -11,5 +13,8 @@ public class CrateList {
 	// Correlates a particular falling block to a crate object that contains information about
 	// what's in the crate, where it is etc.
 	public static Map<FallingBlock, Crate> crateMap = new HashMap<FallingBlock, Crate>();
+	
+	// ArrayList of the locations of created barrels
+	public static ArrayList<Location> barrelList = new ArrayList<Location>();
 
 }

--- a/src/me/lukemccon/airdrop/listeners/BarrelInventoryCloseListener.java
+++ b/src/me/lukemccon/airdrop/listeners/BarrelInventoryCloseListener.java
@@ -1,0 +1,34 @@
+package me.lukemccon.airdrop.listeners;
+
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.block.Barrel;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
+
+import me.lukemccon.airdrop.helpers.CrateList;
+
+public class BarrelInventoryCloseListener implements Listener {
+	
+	@EventHandler(priority = EventPriority.NORMAL)
+	public void onInventoryClose(InventoryCloseEvent e) {
+				
+		if (e.getInventory().getType() != InventoryType.BARREL)
+			return;
+		
+		Barrel barrel = (Barrel) e.getInventory().getHolder();
+		
+		if (CrateList.barrelList.contains(barrel.getBlock().getLocation())) {
+			if(barrel.getInventory().isEmpty()) {
+				barrel.getWorld().playEffect(barrel.getLocation(), Effect.STEP_SOUND, Material.BARREL);
+				barrel.getBlock().setType(Material.AIR);
+				CrateList.barrelList.remove(barrel.getBlock().getLocation());
+			}
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Falling chests are now barrels so that they don't need to be retextured when they hit the ground. Also they are attached to a chicken parachute where the chickens will fly away when the barrel touches the ground. Smoke trail included too. Barrels will break themselves when their inventories have been emptied (doesn't work if server has been reloaded because their locations aren't stored on disk).
Added dropzone command. Usage:
/dropzone setWorld // Sets the world that the dropzone is being made in to the users current world
/dropzone setCorner1/setCorner2 // Sets the x/z bounds for the two corners of the dropzone
/dropzone setFrequency <int> // Sets the frequency of airdrops in seconds
/dropzone enable/disable // Turns the dropzone on and off

This is a basic implementation and only 1 dropzone can be active at a time.